### PR TITLE
CR-10: Try to fix skipping user authentication 

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -6,15 +6,13 @@
 class StaticController < ApplicationController
   include HighVoltage::StaticPage
 
-  before_action :authenticate_user!
-
   ##
   # IMPORTANT: It is ok to disable forgery protection here since static content is trusted.
   #
   # Security warning: an embedded <script> tag on another site requested protected JavaScript. If you know what you're doing, go
   # ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.
   #
-  protect_from_forgery except: :show
+  protect_from_forgery except: :show, prepend: true
 
   def show
     ##

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -12,7 +12,9 @@ class StaticController < ApplicationController
   # Security warning: an embedded <script> tag on another site requested protected JavaScript. If you know what you're doing, go
   # ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.
   #
-  protect_from_forgery except: :show, prepend: true
+  protect_from_forgery except: :show
+
+  before_action :authenticate_user!
 
   def show
     ##


### PR DESCRIPTION
## What was done as a part of this PR?

- Changed the order of `protect_from_forgery`  and `before_action :authenticate_user!` in the `StaticController`.

## Why it was done?
- To fix user authentication.

## How to test?
- Sign out or don't login in at https://code-review.fly.dev/rules/
- Go to https://code-review.fly.dev/rules/ 
- Check if you have access to see this page.

## Notes
- The usage of `before_action` and `protect_from_forgery` together is unpredictable and needs deeper investigation.

## Sources
- [Rails Doc](https://guides.rubyonrails.org/v5.0/upgrading_ruby_on_rails.html#protect-from-forgery-now-defaults-to-prepend-false).
- [Devise](https://github.com/heartcombo/devise/blob/main/README.md#controller-filters-and-helpers).

## Open Questions?
- All the info is related to rails 5, what about 7? 
